### PR TITLE
ci: push container image to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
     concurrency: deploy-group
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
-          images: 'rikhuijzer/fx'
+          images: |
+            rikhuijzer/fx
+            ghcr.io/${{ github.repository }}
       - run: rustup update stable
       - run: rustup default stable
       - run: cargo install --debug jas@0.3.0


### PR DESCRIPTION
Dockerhub has very strict pull rate limits, 10 pulls/hour. This PR adds support for pushing the image to GitHub Container Registry which would be better integrated into your repository here and doesn't have aggressive pull limits.