### PR TITLE
fix: let the url with slug be canonical

### DIFF
--- a/fx/src/data.rs
+++ b/fx/src/data.rs
@@ -225,7 +225,7 @@ fn init_data(args: &ServeArgs, conn: &Connection) {
     };
     init_kv_data(conn, "about", about.as_bytes());
     init_kv_data(conn, "author_name", b"John");
-    init_kv_data(conn, "dark_mode", b"on");
+    init_kv_data(conn, "dark_mode", b"off");
 
     let domain = if args.production { "" } else { "localhost" };
     init_kv_data(conn, "domain", domain.as_bytes());
@@ -282,7 +282,7 @@ fn init_data(args: &ServeArgs, conn: &Connection) {
         };
         File::insert(conn, &file).unwrap();
 
-        let feeds = "https://simonwillison.net/atom/everything/";
+        let feeds = "https://susam.net/feed.xml";
         Kv::insert(conn, BLOGROLL_SETTINGS_KEY, feeds.as_bytes()).unwrap();
     }
 }

--- a/fx/src/html.rs
+++ b/fx/src/html.rs
@@ -196,14 +196,14 @@ pub fn wrap_post_content(post: &Post, slug: &str, is_front_page_preview: bool) -
                     {updated}
                 </div>
             {post_link_end}
-            <div data-post-id='{}' class='post-content {post_preview_class}'>
+            <div data-post-link='{}' class='post-content {post_preview_class}'>
             {html}
             </div>
             {share_link}
         </div>
         ",
         show_date(&post.created),
-        post.id
+        post_link(post, slug)
     )
 }
 

--- a/fx/src/html.rs
+++ b/fx/src/html.rs
@@ -116,7 +116,7 @@ fn test_set_header_id() {
 }
 
 /// Generate a post link with given slug.
-/// 
+///
 /// Will also create a valid post link if the slug is empty.
 pub fn post_link(post: &Post, slug: &str) -> String {
     if slug.is_empty() {

--- a/fx/src/html.rs
+++ b/fx/src/html.rs
@@ -43,21 +43,6 @@ pub fn show_date<Tz: chrono::TimeZone>(datetime: &DateTime<Tz>) -> String {
 const SET_LEAVE_CONFIRMATION: &str = "window.onbeforeunload = () => true;";
 const UNSET_LEAVE_CONFIRMATION: &str = "window.onbeforeunload = null;";
 
-fn turn_title_into_link(post: &Post, html: &str) -> String {
-    let html = html.trim();
-    let title = html.split("\n").next().unwrap();
-    let rest = html.split("\n").skip(1).collect::<Vec<&str>>().join("\n");
-    if title.starts_with("# ") {
-        let title = title.trim_start_matches("# ");
-        format!(
-            "<h1><a href='/posts/{}' class='unstyled-link'>{}</a></h1>\n{}",
-            post.id, title, rest
-        )
-    } else {
-        html.to_string()
-    }
-}
-
 /// Automatically set the `id` attribute for headers.
 ///
 /// pulldown-cmark supports header attributes, but markdown-rs does not. That's
@@ -137,15 +122,10 @@ pub fn wrap_post_content(post: &Post, is_front_page_preview: bool) -> String {
     // work. Either the area was clickable or the text was selectable but not
     // both.
     let html = if is_front_page_preview {
-        turn_title_into_link(post, &post.content)
-    } else {
-        post.content.clone()
-    };
-    let html = if is_front_page_preview {
         // Front page preview is already HTML.
-        html
+        post.content.clone()
     } else {
-        crate::md::content_to_html(&html)
+        crate::md::content_to_html(&post.content)
     };
     let html = set_header_id(&html);
     let style = if is_front_page_preview {

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -184,6 +184,7 @@ pub fn preview(post: &mut Post, max_length: usize) {
     let options = parse_options();
     let tree = to_mdast(&post.content, &options).unwrap();
     let mut preview = String::new();
+    let slug = crate::md::extract_slug(post);
     for node in tree.children().unwrap() {
         if max_length < preview.len() {
             let id = post.id;
@@ -191,7 +192,7 @@ pub fn preview(post: &mut Post, max_length: usize) {
             let expand = format!(
                 "
                 <p>
-                    <a href='/posts/{id}' style='{style}'>
+                    <a href='/posts/{id}/{slug}' style='{style}'>
                         Show more
                     </a>
                 </p>

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -309,7 +309,7 @@ pub fn extract_html_title(post: &Post) -> String {
 ///
 /// For example, a post with the title `Foo Bar` and id `1` would receive the
 /// slug `foo-bar` so that the post can be shared as `/posts/1/foo-bar`.
-/// 
+///
 /// This function should be called before `crate::md::preview` because otherwise
 /// the content is converted to Markdown and texts such as `<p><a href` will end
 /// up in the slug

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -309,6 +309,10 @@ pub fn extract_html_title(post: &Post) -> String {
 ///
 /// For example, a post with the title `Foo Bar` and id `1` would receive the
 /// slug `foo-bar` so that the post can be shared as `/posts/1/foo-bar`.
+/// 
+/// This function should be called before `crate::md::preview` because otherwise
+/// the content is converted to Markdown and texts such as `<p><a href` will end
+/// up in the slug
 pub fn extract_slug(post: &Post) -> String {
     let title = extract_html_title(post);
     let slug = title.replace(" ", "-");

--- a/fx/src/search.rs
+++ b/fx/src/search.rs
@@ -107,9 +107,10 @@ async fn get_search(
     let results = results
         .iter_mut()
         .map(|p| {
+            let slug = crate::md::extract_slug(p);
             crate::md::preview(p, 60);
             let is_front_page_preview = true;
-            wrap_post_content(p, is_front_page_preview)
+            wrap_post_content(p, &slug, is_front_page_preview)
         })
         .collect::<Vec<_>>();
     let results = results.join("\n");

--- a/fx/src/serve.rs
+++ b/fx/src/serve.rs
@@ -389,7 +389,8 @@ async fn get_post(
     // Open Graph uses ISO 8601 according to <https://ogp.me/>.
     let created = iso8601(&post.created);
     let updated = iso8601(&post.updated);
-    let canonical = format!("{}/posts/{}", &ctx.base_url(), &post.id);
+    let slug = crate::md::extract_slug(&post);
+    let canonical = format!("{}/posts/{}/{slug}", &ctx.base_url(), &post.id);
     let extra_head = indoc::formatdoc! {r#"
         <meta property='article:author' content='{author}'/>
         <meta property='article:published_time' content='{created}'/>

--- a/fx/src/serve.rs
+++ b/fx/src/serve.rs
@@ -184,8 +184,9 @@ async fn list_posts(ctx: &ServerContext, page: usize) -> (bool, String) {
     let posts = posts
         .iter_mut()
         .map(|post| {
+            let slug = crate::md::extract_slug(post);
             crate::md::preview(post, 600);
-            wrap_post_content(post, true)
+            wrap_post_content(post, &slug, true)
         })
         .collect::<Vec<String>>();
     (has_next, posts.join("\n"))
@@ -331,7 +332,7 @@ async fn get_delete(
             <br>
         </div>
     "#};
-    let body = format!("{}\n{}", delete_button, wrap_post_content(&post, false));
+    let body = format!("{}\n{}", delete_button, wrap_post_content(&post, "", false));
     let body = page(&ctx, &settings, &body).await;
     response::<String>(StatusCode::OK, HeaderMap::new(), body, &ctx)
 }
@@ -401,7 +402,7 @@ async fn get_post(
         {}
     "#, ctx.args.extra_head};
     let settings = PageSettings::new(&title, Some(is_logged_in), false, Top::GoHome, &extra_head);
-    let mut body = wrap_post_content(&post, false);
+    let mut body = wrap_post_content(&post, "", false);
     if is_logged_in {
         body = format!("{}\n{body}", crate::html::edit_post_buttons(&ctx, &post));
     }
@@ -593,7 +594,7 @@ async fn post_edit(
         crate::trigger::trigger_github_backup(&ctx).await;
         see_other(&ctx, &url)
     } else {
-        let preview = crate::html::wrap_post_content(&post, false);
+        let preview = crate::html::wrap_post_content(&post, "", false);
         let body = page(&ctx, &settings, &preview).await;
         response(StatusCode::OK, HeaderMap::new(), body, &ctx)
     }
@@ -655,7 +656,7 @@ async fn post_add(
             content: form.content,
         };
         let is_front_page_preview = false;
-        let preview = crate::html::wrap_post_content(&post, is_front_page_preview);
+        let preview = crate::html::wrap_post_content(&post, "", is_front_page_preview);
         let body = page(&ctx, &settings, &preview).await;
         response(StatusCode::OK, HeaderMap::new(), body, &ctx)
     }

--- a/fx/src/serve.rs
+++ b/fx/src/serve.rs
@@ -402,7 +402,7 @@ async fn get_post(
         {}
     "#, ctx.args.extra_head};
     let settings = PageSettings::new(&title, Some(is_logged_in), false, Top::GoHome, &extra_head);
-    let mut body = wrap_post_content(&post, "", false);
+    let mut body = wrap_post_content(&post, &slug, false);
     if is_logged_in {
         body = format!("{}\n{body}", crate::html::edit_post_buttons(&ctx, &post));
     }

--- a/fx/src/serve.rs
+++ b/fx/src/serve.rs
@@ -406,7 +406,11 @@ async fn get_post_with_slug(
     response::<String>(StatusCode::OK, HeaderMap::new(), body, &ctx)
 }
 
-async fn get_post(State(ctx): State<ServerContext>, Path(id): Path<i64>) -> Response<Body> {
+async fn get_post(State(ctx): State<ServerContext>, Path(id): Path<String>) -> Response<Body> {
+    let id = match id.parse::<i64>() {
+        Ok(id) => id,
+        Err(_) => return not_found(State(ctx)).await,
+    };
     let post = Post::get(&*ctx.conn().await, id);
     let post = match post {
         Ok(post) => post,

--- a/fx/src/static/script.js
+++ b/fx/src/static/script.js
@@ -12,9 +12,8 @@ function make_post_previews_clickable() {
                 // Don't navigate if the user has selected text.
                 return;
             }
-            const post_id = post_preview.getAttribute("data-post-id");
-            window.location.href = `/posts/${post_id}`;
-
+            const post_id = post_preview.getAttribute("data-post-link");
+            window.location.href = `${post_id}`;
         });
         post_preview.style.cursor = "pointer";
     });

--- a/fx/tests/integration.rs
+++ b/fx/tests/integration.rs
@@ -29,12 +29,7 @@ async fn test_home() {
 
 #[tokio::test]
 async fn test_get_post() {
-    let (status, body) = request_body("/posts/1").await;
-    assert_eq!(status, StatusCode::OK);
-    println!("body:\n{body}");
-    assert!(body.contains("Lorem"));
-
-    let (status, body) = request_body("/posts/2").await;
+    let (status, body) = request_body("/posts/2/code").await;
     assert_eq!(status, StatusCode::OK);
     assert!(body.contains("Dolor"));
     assert!(body.contains("<h2 id='more'>More</h2>"));
@@ -43,7 +38,7 @@ async fn test_get_post() {
     assert!(body.contains("<meta property='og:type' content='article'/>"));
     assert!(body.contains("<meta property='og:title' content='Code'/>"));
 
-    let (status, _body) = request_body("/posts/2/dolor").await;
+    let (status, _body) = request_body("/posts/2").await;
     assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
 }
 
@@ -76,7 +71,8 @@ async fn test_style() {
 
 #[tokio::test]
 async fn test_metadata() {
-    let (status, body) = request_body("/posts/1").await;
+    let url = "/posts/1/lorem-ipsum-ut-enim-ad-minim-veniam-sit-amet-ipsum";
+    let (status, body) = request_body(url).await;
     assert_eq!(status, StatusCode::OK);
     let lines = body.lines().collect::<Vec<_>>();
     let head_start = lines


### PR DESCRIPTION
Currently in google search console it's very hard to see which pages are visited most since the canonical url only shows the number.

Fixes #74.