### PR TITLE
build: bump debian from 12 to 13

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,7 +57,7 @@ release:
     fi
 
     cat > public/Dockerfile << EOF
-    FROM gcr.io/distroless/cc-debian12
+    FROM gcr.io/distroless/cc-debian13
     ENV FX_PRODUCTION="true"
     COPY fx /
     CMD ["/fx", "serve"]


### PR DESCRIPTION
Should probably fix
```
/fx: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /fx)
```