### PR TITLE
fix: derive post description from post content

### DIFF
--- a/fx/src/blogroll.rs
+++ b/fx/src/blogroll.rs
@@ -100,7 +100,14 @@ async fn get_blogroll(State(ctx): State<ServerContext>, jar: CookieJar) -> Respo
     let is_logged_in = is_logged_in(&ctx, &jar);
     let extra_head = Kv::get_or_empty_string(&ctx.conn(), "extra_head");
     let title = "Blogroll";
-    let settings = PageSettings::new(title, Some(is_logged_in), false, Top::GoHome, &extra_head);
+    let settings = PageSettings::new(
+        title,
+        Some(is_logged_in),
+        None,
+        false,
+        Top::GoHome,
+        &extra_head,
+    );
 
     let last_update = ctx.blog_cache.lock().await.last_updated;
     let items = &ctx.blog_cache.lock().await.items;

--- a/fx/src/discovery.rs
+++ b/fx/src/discovery.rs
@@ -60,7 +60,7 @@ async fn rss(ctx: &ServerContext, posts: &[Post]) -> String {
     ));
     for post in posts {
         let title = escape_xml(&crate::md::extract_html_title(post));
-        let description = escape_xml(&crate::md::extract_html_description(post));
+        let description = &crate::md::extract_html_description(post);
         let url = format!("{base}/posts/{}", post.id);
         let created = rfc822_datetime(&post.created);
         let entry = format!(
@@ -70,7 +70,7 @@ async fn rss(ctx: &ServerContext, posts: &[Post]) -> String {
             <link>{url}</link>
             <guid>{url}</guid>
             <pubDate>{created}</pubDate>
-            <description>{description}</description>
+            <description><![CDATA[{description}]]</description>
             </item>
             "
         );

--- a/fx/src/discovery.rs
+++ b/fx/src/discovery.rs
@@ -60,7 +60,7 @@ async fn rss(ctx: &ServerContext, posts: &[Post]) -> String {
     ));
     for post in posts {
         let title = escape_xml(&crate::md::extract_html_title(post));
-        let description = &crate::md::extract_html_description(post);
+        let description = &crate::md::extract_rss_description(post);
         let url = format!("{base}/posts/{}", post.id);
         let created = rfc822_datetime(&post.created);
         let entry = format!(

--- a/fx/src/files.rs
+++ b/fx/src/files.rs
@@ -248,7 +248,8 @@ async fn get_files(State(ctx): State<ServerContext>, jar: CookieJar) -> Response
         </div>
         "
     );
-    let page_settings = PageSettings::new("Files", Some(is_logged_in), false, Top::GoHome, "");
+    let page_settings =
+        PageSettings::new("Files", Some(is_logged_in), None, false, Top::GoHome, "");
     let body = page(&ctx, &page_settings, &body).await;
     tracing::info!("\"GET /files HTTP/1.1\" 200");
     response(StatusCode::OK, HeaderMap::new(), body, &ctx)
@@ -347,7 +348,14 @@ async fn get_delete(
     };
     let extra_head = &Kv::get_or_empty_string(&ctx.conn(), "extra_head");
     let title = format!("Delete: {}", file.filename);
-    let settings = PageSettings::new(&title, Some(is_logged_in), false, Top::GoHome, extra_head);
+    let settings = PageSettings::new(
+        &title,
+        Some(is_logged_in),
+        None,
+        false,
+        Top::GoHome,
+        extra_head,
+    );
     let body = indoc::formatdoc! {r#"
         <div class='medium-text' style='text-align: center; font-weight: bold;'>
             <p>Are you sure you want to delete <code>{}</code>? This action cannot be undone.</p>
@@ -392,7 +400,14 @@ async fn get_rename(
     };
     let extra_head = &Kv::get_or_empty_string(&ctx.conn(), "extra_head");
     let title = format!("Rename: {}", file.filename);
-    let settings = PageSettings::new(&title, Some(is_logged_in), false, Top::GoHome, extra_head);
+    let settings = PageSettings::new(
+        &title,
+        Some(is_logged_in),
+        None,
+        false,
+        Top::GoHome,
+        extra_head,
+    );
     let body = indoc::formatdoc! {r#"
         <div class='medium-text' style='text-align: center;'>
             <p>Rename file: <code>{}</code></p>

--- a/fx/src/html.rs
+++ b/fx/src/html.rs
@@ -231,6 +231,8 @@ pub struct PageSettings {
     ///
     /// None means don't show login/logout buttons.
     is_logged_in: Option<bool>,
+    /// The description of the page, defaults to the site description.
+    description: Option<String>,
     show_about: bool,
     top: Top,
     extra_head: String,
@@ -240,6 +242,7 @@ impl PageSettings {
     pub fn new(
         title: &str,
         is_logged_in: Option<bool>,
+        description: Option<&str>,
         show_about: bool,
         top: Top,
         extra_head: &str,
@@ -247,6 +250,7 @@ impl PageSettings {
         Self {
             title: title.to_string(),
             is_logged_in,
+            description: description.map(|s| s.to_string()),
             show_about,
             top,
             extra_head: extra_head.to_string(),
@@ -590,7 +594,10 @@ pub async fn page(ctx: &ServerContext, settings: &PageSettings, body: &str) -> S
     let site_name = Kv::get(&ctx.conn(), "site_name").unwrap();
     let site_name = String::from_utf8(site_name).unwrap();
     let site_name = escape_single_quote(&site_name);
-    let site_description = Kv::get_or_empty_string(&ctx.conn(), "site_description");
+    let description = match &settings.description {
+        Some(description) => description.clone(),
+        None => Kv::get_or_empty_string(&ctx.conn(), "site_description"),
+    };
     let full_title = if settings.title.is_empty() {
         site_name.clone()
     } else {
@@ -654,8 +661,8 @@ pub async fn page(ctx: &ServerContext, settings: &PageSettings, body: &str) -> S
             <link rel='alternate' type='application/rss+xml' href='/feed.xml'>
             <script src='/static/script.js' defer></script>
             <title>{full_title}</title>
-            <meta name='description' content='{site_description}'/>
-            <meta property='og:description' content='{site_description}'/>
+            <meta name='description' content='{description}'/>
+            <meta property='og:description' content='{description}'/>
             <meta property='og:site_name' content='{site_name}'/>
             <meta property='og:title' content='{og_title}'/>
             {katex}
@@ -685,7 +692,8 @@ pub async fn page(ctx: &ServerContext, settings: &PageSettings, body: &str) -> S
 
 pub async fn login(ctx: &ServerContext, error: Option<&str>) -> String {
     let top = Top::Homepage;
-    let settings = PageSettings::new("Login", None, false, top, "");
+    let description = "Login to the website";
+    let settings = PageSettings::new("Login", None, Some(&description), false, top, "");
     let error = match error {
         Some(error) => format!("<div style='font-style: italic;'>{error}</div>"),
         None => "".to_string(),

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -320,10 +320,12 @@ pub fn extract_html_description(post: &Post) -> String {
     };
     let description = remove_urls(&description);
     let mut description = description
-        .replace("<", "")
-        .replace(">", "")
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
         .replace("\n", " ")
-        .replace("'", "\"");
+        .replace("'", "&apos;")
+        .replace("\"", "&quot;");
     while description.contains("  ") {
         description = description.replace("  ", " ");
     }

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -306,6 +306,40 @@ pub fn extract_html_title(post: &Post) -> String {
     }
 }
 
+/// Description for the meta description and Open Graph description.
+pub fn extract_html_description(post: &Post) -> String {
+    let content = &post.content;
+    // This also would make a post with a single word on the first line have
+    // that as the title which I guess makes sense.
+    let first_line = content.split("\n").next().unwrap();
+    let has_title = first_line.starts_with("# ");
+    let description = if has_title {
+        content.trim_start_matches(first_line).trim()
+    } else {
+        content.trim()
+    };
+    let description = remove_urls(description);
+    // Better a bit too long than too short. Google truncates anyway.
+    let max_length = 200;
+    if description.len() <= max_length {
+        description
+    } else {
+        format!("{}...", truncate(&description, max_length))
+    }
+}
+
+#[test]
+fn test_extract_html_description() {
+    let post = Post {
+        id: 0,
+        content: "# Title\nipsum".to_string(),
+        created: chrono::Utc::now(),
+        updated: chrono::Utc::now(),
+    };
+    let description = extract_html_description(&post);
+    assert_eq!(description, "ipsum");
+}
+
 /// Extract a slug (a short URL suffix to clarify the post) from the post.
 ///
 /// For example, a post with the title `Foo Bar` and id `1` would receive the
@@ -353,7 +387,7 @@ fn test_extract_slug() {
 ///
 /// Many readers expect the description to be the full post, see for example,
 /// <https://stackoverflow.com/a/7369487/5056635>.
-pub fn extract_html_description(post: &Post) -> String {
+pub fn extract_rss_description(post: &Post) -> String {
     let mut post = post.clone();
     // Should not truncate the post, but instead implement feed pages.
     preview(&mut post, 600);
@@ -367,7 +401,7 @@ mod test {
     use chrono::Utc;
 
     #[test]
-    fn test_extract_html_title_and_description() {
+    fn test_extract_html_title_and_rss_description() {
         let post = Post {
             id: 0,
             content: "[lorem](https://example.com/lorem) ipsum".to_string(),
@@ -385,7 +419,7 @@ mod test {
         };
         let title = extract_html_title(&post);
         assert_eq!(title, "Title");
-        let description = extract_html_description(&post);
+        let description = extract_rss_description(&post);
         assert_eq!(description, "ipsum");
     }
 }

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -349,6 +349,7 @@ fn test_extract_slug() {
     assert_eq!(extract_slug(&post), "lorem--ipsum");
 }
 
+/// Used for RSS feed.
 pub fn extract_html_description(post: &Post) -> String {
     let content = post.content.trim();
     let title = extract_html_title(post);

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -351,12 +351,12 @@ fn test_extract_html_description() {
 
     let post = Post {
         id: 0,
-        content: "<example.com> ipsum".to_string(),
+        content: "lorem & ipsum".to_string(),
         created: chrono::Utc::now(),
         updated: chrono::Utc::now(),
     };
     let description = extract_html_description(&post);
-    assert_eq!(description, "example.com ipsum");
+    assert_eq!(description, "lorem &amp; ipsum");
 }
 
 /// Extract a slug (a short URL suffix to clarify the post) from the post.

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -349,23 +349,16 @@ fn test_extract_slug() {
     assert_eq!(extract_slug(&post), "lorem--ipsum");
 }
 
-/// Used for RSS feed.
+/// Used for RSS feed description field.
+///
+/// Many readers expect the description to be the full post, see for example,
+/// <https://stackoverflow.com/a/7369487/5056635>.
 pub fn extract_html_description(post: &Post) -> String {
-    let content = post.content.trim();
-    let title = extract_html_title(post);
-    let title = title.trim_end_matches("...");
-    let description = remove_urls(content);
-    let description = description.trim_start_matches("# ");
-    let description = description.trim_start_matches(title).trim();
-    let description = remove_urls(description);
-    // This allows RSS readers to read the full quote when the page is a
-    // microblog and still truncates to avoid having a too heavy RSS feed.
-    let max_length = 600;
-    if description.len() <= max_length {
-        description
-    } else {
-        format!("{}...", truncate(&description, max_length))
-    }
+    let mut post = post.clone();
+    // Should not truncate the post, but instead implement feed pages.
+    preview(&mut post, 600);
+    let html = content_to_html(&post.content);
+    html
 }
 
 #[cfg(test)]

--- a/fx/src/md.rs
+++ b/fx/src/md.rs
@@ -311,14 +311,22 @@ pub fn extract_html_description(post: &Post) -> String {
     let content = &post.content;
     // This also would make a post with a single word on the first line have
     // that as the title which I guess makes sense.
-    let first_line = content.split("\n").next().unwrap();
-    let has_title = first_line.starts_with("# ");
+    let lines = content.lines().collect::<Vec<&str>>();
+    let has_title = lines.first().unwrap().starts_with("# ");
     let description = if has_title {
-        content.trim_start_matches(first_line).trim()
+        lines[1..].join("\n")
     } else {
-        content.trim()
+        lines.join("\n")
     };
-    let description = remove_urls(description);
+    let description = remove_urls(&description);
+    let mut description = description
+        .replace("<", "")
+        .replace(">", "")
+        .replace("\n", " ")
+        .replace("'", "\"");
+    while description.contains("  ") {
+        description = description.replace("  ", " ");
+    }
     // Better a bit too long than too short. Google truncates anyway.
     let max_length = 200;
     if description.len() <= max_length {
@@ -338,6 +346,15 @@ fn test_extract_html_description() {
     };
     let description = extract_html_description(&post);
     assert_eq!(description, "ipsum");
+
+    let post = Post {
+        id: 0,
+        content: "<example.com> ipsum".to_string(),
+        created: chrono::Utc::now(),
+        updated: chrono::Utc::now(),
+    };
+    let description = extract_html_description(&post);
+    assert_eq!(description, "example.com ipsum");
 }
 
 /// Extract a slug (a short URL suffix to clarify the post) from the post.
@@ -420,6 +437,6 @@ mod test {
         let title = extract_html_title(&post);
         assert_eq!(title, "Title");
         let description = extract_rss_description(&post);
-        assert_eq!(description, "ipsum");
+        assert_eq!(description, "<h1>Title</h1>\n<p>ipsum</p>");
     }
 }

--- a/fx/src/search.rs
+++ b/fx/src/search.rs
@@ -125,7 +125,14 @@ async fn get_search(
     content_type(&mut headers, "text/html");
     let title = "Search";
     let extra_head = &Kv::get_or_empty_string(&ctx.conn(), "extra_head");
-    let settings = PageSettings::new(title, Some(is_logged_in), false, Top::GoHome, extra_head);
+    let settings = PageSettings::new(
+        title,
+        Some(is_logged_in),
+        None,
+        false,
+        Top::GoHome,
+        extra_head,
+    );
     let body = page(&ctx, &settings, &body).await;
     response(StatusCode::OK, headers, body, &ctx)
 }

--- a/fx/src/serve.rs
+++ b/fx/src/serve.rs
@@ -410,7 +410,7 @@ async fn get_post_with_slug(
         <link rel='canonical' href='{canonical}'/>
         {}
     "#, &extra_head};
-    let description = "todo";
+    let description = crate::md::extract_html_description(&post);
     let settings = PageSettings::new(
         &title,
         Some(is_logged_in),

--- a/fx/src/serve.rs
+++ b/fx/src/serve.rs
@@ -117,7 +117,7 @@ pub async fn error(
 ) -> Response<Body> {
     let body = msg.to_string();
     let headers = HeaderMap::new();
-    let settings = PageSettings::new(title, None, false, Top::GoHome, "");
+    let settings = PageSettings::new(title, None, None, false, Top::GoHome, "");
     let body = format!(
         "
         <div style='text-align: center;'>
@@ -228,7 +228,7 @@ async fn get_posts(
     } else {
         Top::GoHome
     };
-    let settings = PageSettings::new("", is_logged_in, show_about, top, &extra_head);
+    let settings = PageSettings::new("", is_logged_in, None, show_about, top, &extra_head);
     let (has_next, posts) = list_posts(&ctx, current_page).await;
     let prev_link = if current_page == 1 {
         ""
@@ -325,7 +325,14 @@ async fn get_delete(
     };
     let extra_head = &Kv::get_or_empty_string(&ctx.conn(), "extra_head");
     let title = crate::md::extract_html_title(&post);
-    let settings = PageSettings::new(&title, Some(is_logged_in), false, Top::GoHome, extra_head);
+    let settings = PageSettings::new(
+        &title,
+        Some(is_logged_in),
+        None,
+        false,
+        Top::GoHome,
+        extra_head,
+    );
     let delete_button = indoc::formatdoc! {r#"
         <div class='medium-text' style='text-align: center; font-weight: bold;'>
             <p>Are you sure you want to delete this post? This action cannot be undone.</p>
@@ -355,7 +362,14 @@ async fn get_edit(
     let title = format!("Edit '{title}'");
     let body = crate::html::edit_post_form(&post);
     let extra_head = Kv::get_or_empty_string(&ctx.conn(), "extra_head");
-    let settings = PageSettings::new(&title, Some(is_logged_in), false, Top::GoBack, &extra_head);
+    let settings = PageSettings::new(
+        &title,
+        Some(is_logged_in),
+        None,
+        false,
+        Top::GoBack,
+        &extra_head,
+    );
     let body = page(&ctx, &settings, &body).await;
     response::<String>(StatusCode::OK, HeaderMap::new(), body, &ctx)
 }
@@ -396,7 +410,15 @@ async fn get_post_with_slug(
         <link rel='canonical' href='{canonical}'/>
         {}
     "#, &extra_head};
-    let settings = PageSettings::new(&title, Some(is_logged_in), false, Top::GoHome, &extra_head);
+    let description = "todo";
+    let settings = PageSettings::new(
+        &title,
+        Some(is_logged_in),
+        Some(&description),
+        false,
+        Top::GoHome,
+        &extra_head,
+    );
     let mut body = wrap_post_content(&post, &slug, false);
     if is_logged_in {
         body = format!("{}\n{body}", crate::html::edit_post_buttons(&ctx, &post));
@@ -463,6 +485,7 @@ pub async fn not_found(State(ctx): State<ServerContext>) -> Response<Body> {
     let settings = PageSettings::new(
         "not found",
         Some(is_logged_in),
+        None,
         false,
         Top::GoHome,
         &extra_head,
@@ -599,7 +622,7 @@ async fn post_edit(
         return not_found(State(ctx)).await;
     }
     let extra_head = &Kv::get_or_empty_string(&ctx.conn(), "extra_head");
-    let settings = PageSettings::new("", Some(is_logged_in), false, Top::GoBack, extra_head);
+    let settings = PageSettings::new("", Some(is_logged_in), None, false, Top::GoBack, extra_head);
     let (_, body) = req.into_parts();
     let bytes = body
         .collect()
@@ -662,7 +685,7 @@ async fn post_add(
         return not_found(State(ctx)).await;
     }
     let extra_head = &Kv::get_or_empty_string(&ctx.conn(), "extra_head");
-    let settings = PageSettings::new("", Some(is_logged_in), false, Top::GoBack, extra_head);
+    let settings = PageSettings::new("", Some(is_logged_in), None, false, Top::GoBack, extra_head);
     let (_, body) = req.into_parts();
     let bytes = body
         .collect()

--- a/fx/src/settings.rs
+++ b/fx/src/settings.rs
@@ -224,7 +224,8 @@ async fn get_settings(State(ctx): State<ServerContext>, jar: CookieJar) -> Respo
             false,
         )
     );
-    let page_settings = PageSettings::new("Settings", Some(is_logged_in), false, Top::GoHome, "");
+    let page_settings =
+        PageSettings::new("Settings", Some(is_logged_in), None, false, Top::GoHome, "");
     let body = page(&ctx, &page_settings, &body).await;
     response(StatusCode::OK, HeaderMap::new(), body, &ctx)
 }

--- a/fx/tests/integration.rs
+++ b/fx/tests/integration.rs
@@ -307,14 +307,8 @@ async fn test_rss() {
     assert_eq!(status, StatusCode::OK);
     println!("body:\n{body}");
     assert!(body.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
-    assert!(
-        !body.contains("<description>Lorem ipsum"),
-        "description without title"
-    );
-    assert!(
-        body.contains("<description>`Dolor sit amet"),
-        "description with title"
-    );
+    assert!(body.contains("<description><![CDATA[<p><a href='https://example.com"),);
+    assert!(body.contains("<description><![CDATA[<h1>Code</h1>"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fix #128.

Also put HTML in feed description instead of Markdown