### PR TITLE
feat: show PDFs and other files in sitemap

### DIFF
--- a/fx/src/discovery.rs
+++ b/fx/src/discovery.rs
@@ -1,5 +1,6 @@
 //! Discovery protocols such as sitemap.xml, rss and robots.
 use crate::data::Post;
+use crate::files::File;
 use crate::serve::ServerContext;
 use crate::serve::content_type;
 use crate::serve::response;
@@ -118,13 +119,25 @@ fn sitemap(ctx: &ServerContext, posts: &[Post]) -> String {
     let base = ctx.base_url();
     body.push_str(&format!("<url><loc>{base}/</loc></url>\n"));
     for post in posts {
-        let url = format!("{}/posts/{}", base, post.id);
+        let url = format!("{base}/posts/{}", post.id);
         let updated = w3_datetime(&post.updated);
         let entry = format!(
             "
             <url>
             <loc>{url}</loc>
             <lastmod>{updated}</lastmod>
+            </url>
+            "
+        );
+        body.push_str(&entry);
+    }
+    let files = File::list(&ctx.conn()).unwrap();
+    for file in files {
+        let url = format!("{base}/files/{}/{}", file.sha, file.filename);
+        let entry = format!(
+            "
+            <url>
+            <loc>{url}</loc>
             </url>
             "
         );

--- a/fx/src/files.rs
+++ b/fx/src/files.rs
@@ -142,7 +142,7 @@ impl File {
     }
 }
 
-fn file_ext(file: &File) -> String {
+pub fn file_ext(file: &File) -> String {
     let filename = &file.filename;
     if file.mime_type.starts_with("image/") {
         // For images, the extension is not important since the download link
@@ -160,13 +160,12 @@ fn file_ext(file: &File) -> String {
 }
 
 fn md_link(file: &File) -> String {
-    let filename = &file.filename;
-    let ext = file_ext(file);
     let sha = &file.sha;
+    let filename = &file.filename;
     if file.mime_type.starts_with("image/") {
         format!("![{filename}](/files/{sha})")
     } else {
-        format!("[{filename}](/files/{sha}{ext})")
+        format!("[{filename}](/files/{sha}/{filename})")
     }
 }
 
@@ -243,6 +242,13 @@ async fn get_files(State(ctx): State<ServerContext>, jar: CookieJar) -> Response
                 <br>
             </form>
         </div>
+        <div style='font-size: 0.8rem; padding: 6px; padding-bottom: 10px;'>
+            Each file will get an unique SHA identifier, such as <code>69b83ddf8f65695f</code>.
+            To link to the file, you can use
+            <code>/files/69b83ddf8f65695f</code>,
+            <code>/files/69b83ddf8f65695f/example.txt</code>, or
+            <code>/files/69b83ddf8f65695f/something.txt</code>.
+        </div>
         <div>
             {files}
         </div>
@@ -258,7 +264,8 @@ async fn get_files(State(ctx): State<ServerContext>, jar: CookieJar) -> Response
 async fn get_file(State(ctx): State<ServerContext>, Path(sha): Path<String>) -> Response<Body> {
     // Anything after the sha is allowed. This allows anyone to decide the
     // filename. For security purposes, this should be okay since the only
-    // person that can upload files is the site owner.
+    // person that can upload files is the site owner. The benefit of this is
+    // that files can be renamed without breaking links.
     let trim_len = 16;
     let name = if trim_len < sha.len() {
         sha[..trim_len].to_string()
@@ -282,6 +289,13 @@ async fn get_file(State(ctx): State<ServerContext>, Path(sha): Path<String>) -> 
     crate::serve::enable_caching(&mut headers, max_age);
     tracing::info!("\"GET /files/{sha} HTTP/1.1\" 200");
     response(StatusCode::OK, headers, file.data, &ctx)
+}
+
+async fn get_file_with_filename(
+    State(ctx): State<ServerContext>,
+    Path((sha, _filename)): Path<(String, String)>,
+) -> Response<Body> {
+    get_file(State(ctx), Path(sha)).await
 }
 
 async fn post_file(
@@ -454,6 +468,7 @@ pub fn routes(router: &Router<ServerContext>) -> Router<ServerContext> {
         .clone()
         .route("/files", get(get_files))
         .route("/files/{sha}", get(get_file))
+        .route("/files/{sha}/{filename}", get(get_file_with_filename))
         .route("/files/add", post(post_file))
         .route("/files/delete/{sha}", get(get_delete))
         .route("/files/delete/{sha}", post(post_delete))

--- a/fx/tests/integration.rs
+++ b/fx/tests/integration.rs
@@ -279,6 +279,13 @@ async fn test_allow_filename_suffix() {
 }
 
 #[tokio::test]
+async fn test_allow_filename_suffix_after_forward_slash() {
+    let url = "/files/69b83ddf8f65695f/example.txt";
+    let (status, _body) = request_body(url).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
 async fn test_sitemap() {
     let (status, body) = request_body("/sitemap.xml").await;
     assert_eq!(status, StatusCode::OK);
@@ -289,6 +296,7 @@ async fn test_sitemap() {
     assert!(body.contains("<loc>/posts/1</loc>"));
     assert!(body.contains("<loc>/posts/2</loc>"));
     assert!(body.contains("<lastmod>"));
+    assert!(body.contains("<loc>/files/69b83ddf8f65695f/example.txt</loc>"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #180.

Google indexes PDF's, Word documents, images, source files, and many other formats: https://developers.google.com/search/docs/crawling-indexing/indexable-file-types. To not make too many assumptions, let's just add all files to the sitemap.

